### PR TITLE
Add SwiftUI Boggle game

### DIFF
--- a/BoggleGame/BoggleDice.swift
+++ b/BoggleGame/BoggleDice.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+struct BoggleDice {
+    static let dice: [[String]] = [
+        ["A","A","E","E","G","N"],
+        ["A","B","B","J","O","O"],
+        ["A","C","H","O","P","S"],
+        ["A","F","F","K","P","S"],
+        ["A","O","O","T","T","W"],
+        ["C","I","M","O","T","U"],
+        ["D","E","I","L","R","X"],
+        ["D","E","L","R","V","Y"],
+        ["D","I","S","T","T","Y"],
+        ["E","E","G","H","N","W"],
+        ["E","E","I","N","S","U"],
+        ["E","H","R","T","V","W"],
+        ["E","I","O","S","S","T"],
+        ["E","L","R","T","T","Y"],
+        ["H","I","M","N","U","Qu"],
+        ["H","L","N","N","R","Z"]
+    ]
+
+    static func roll() -> [[String]] {
+        var shuffled = dice.shuffled()
+        var board: [[String]] = []
+        for i in 0..<4 {
+            var row: [String] = []
+            for j in 0..<4 {
+                let die = shuffled[i * 4 + j]
+                row.append(die.randomElement()!)
+            }
+            board.append(row)
+        }
+        return board
+    }
+}

--- a/BoggleGame/BoggleGame.swift
+++ b/BoggleGame/BoggleGame.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+class Player: Identifiable, ObservableObject {
+    let id = UUID()
+    let name: String
+    @Published var score: Int
+
+    init(name: String) {
+        self.name = name
+        self.score = 0
+    }
+}
+
+class BoggleGame: ObservableObject {
+    @Published var board: [[String]] = []
+    @Published var remainingSeconds: Int = 120
+    @Published var isRunning: Bool = false
+
+    var timer: Timer?
+    var players: [Player] = [Player(name: "Player 1"), Player(name: "Player 2")]
+
+    func startGame() {
+        board = BoggleDice.roll()
+        remainingSeconds = 120
+        isRunning = true
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            self?.tick()
+        }
+    }
+
+    func tick() {
+        guard remainingSeconds > 0 else {
+            timer?.invalidate()
+            isRunning = false
+            return
+        }
+        remainingSeconds -= 1
+    }
+
+    func addScore(for playerIndex: Int, points: Int) {
+        players[playerIndex].score += points
+    }
+
+    func resetScores() {
+        players.forEach { $0.score = 0 }
+    }
+}

--- a/BoggleGame/BoggleGameApp.swift
+++ b/BoggleGame/BoggleGameApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct BoggleGameApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/BoggleGame/ContentView.swift
+++ b/BoggleGame/ContentView.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject var game = BoggleGame()
+
+    let columns = Array(repeating: GridItem(.flexible()), count: 4)
+
+    var body: some View {
+        VStack {
+            LazyVGrid(columns: columns, spacing: 8) {
+                ForEach(0..<4, id: .self) { i in
+                    ForEach(0..<4, id: .self) { j in
+                        Text(game.board.indices.contains(i) ? game.board[i][j] : "")
+                            .frame(width: 50, height: 50)
+                            .background(Color.blue.opacity(0.2))
+                            .cornerRadius(4)
+                    }
+                }
+            }
+            .padding()
+
+            Text("Time Remaining: \(game.remainingSeconds)s")
+                .font(.headline)
+                .padding()
+
+            HStack {
+                ForEach(Array(game.players.enumerated()), id: .element.id) { index, player in
+                    VStack {
+                        Text(player.name)
+                        Text("Score: \(player.score)")
+                    }
+                    .padding()
+                }
+            }
+
+            HStack {
+                Button("Start Game") {
+                    game.startGame()
+                }
+                .padding()
+
+                Button("Reset Scores") {
+                    game.resetScores()
+                }
+                .padding()
+            }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/BoggleGame/README.md
+++ b/BoggleGame/README.md
@@ -1,0 +1,8 @@
+# Boggle Game iOS App
+
+This directory contains a simple SwiftUI implementation of a Boggle game. The app generates a standard 4x4 Boggle board using the original letter dice weights, runs a two minute timer, and keeps score for two players across multiple games.
+
+## Building
+
+Open the `BoggleGame` directory in Xcode and build/run on an iOS device or simulator running iOS 14 or later. The project is provided as Swift source files only and can be added to a new Xcode project or Swift Package.
+


### PR DESCRIPTION
## Summary
- create BoggleGame SwiftUI example app
- show standard Boggle dice and board roll logic
- implement game timer and score keeping for two players

## Testing
- `swift --version`
- `swiftc -emit-sil BoggleGame/*.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6853d73bda8c8326b8e68e8b7a8b7fa1